### PR TITLE
Add the initial API.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "k2"
+version = "0.1.0"
+authors = ["Gabriela Alexandra Moldovan <gabi_250@live.com>"]
+edition = "2018"
+
+[lib]
+name = "k2"
+path = "src/lib.rs"
+
+[dependencies]
+clap = "2.33.0"
+which = "2.0.1"

--- a/examples/simple_experiment.rs
+++ b/examples/simple_experiment.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use k2::{
+    benchmark::Benchmark, experiment::ExperimentBuilder, lang_impl::GenericScriptingVm,
+    limit::Limit, util::find_executable,
+};
+
+use clap::{App, Arg};
+
+fn main() {
+    // Note: `find_executable` relies on $PATH. For a real experiment, you will
+    // probably want to use absolute paths instead.
+    let python_bin = find_executable("python");
+    let pypy_bin = find_executable("pypy");
+    let luajit_bin = find_executable("luajit");
+    let expb = setup();
+    let cpython = GenericScriptingVm::new(&python_bin);
+    let pypy = GenericScriptingVm::new(&pypy_bin);
+    let luajit = GenericScriptingVm::new(&luajit_bin);
+    let cpython_bench = Benchmark::new("./benchmarks/binarytrees/binarytrees.py", &cpython)
+        .tag("benchmark_name", "binarytrees");
+    let pypy_bench = Benchmark::new("./benchmarks/binarytrees/binarytrees.py", &pypy)
+        .tag("benchmark_name", "binarytrees");
+    let lua_bench = Benchmark::new("./benchmarks/binarytrees/binarytrees.lua", &luajit)
+        .tag("benchmark_name", "binarytrees")
+        .stack_lim(Limit::KiB(8.192))
+        .heap_lim(Limit::GiB(2.097152));
+    let exp = expb
+        .benchmark(&cpython_bench)
+        .benchmark(&pypy_bench)
+        .benchmark(&lua_bench)
+        .build();
+    // `run` outputs the result in the k2 internal format.
+    let _ = exp.run().expect("Failed to run the experiment");
+}
+
+fn setup<'a>() -> ExperimentBuilder<'a> {
+    let expb = parse_args(ExperimentBuilder::new());
+    // These could've been command-line arguments too.
+    expb.pexecs(2).in_proc_iters(40)
+}
+
+fn parse_args(expb: ExperimentBuilder) -> ExperimentBuilder {
+    // Parse the args and create a `Config`.
+    let matches = App::new("k2")
+        .arg(Arg::with_name("quick")
+                .short("q")
+                .long("quick")
+                .help("Run the benchmarks straight away. For development only."))
+        .arg(Arg::with_name("dry-run")
+                .short("d")
+                .long("dry-run")
+                .help("Don't really run the benchmarks. For development only"))
+        .arg(Arg::with_name("reboot")
+                .long("reboot")
+                .help("Reboot before each benchmark."))
+        .get_matches();
+    expb.quick(matches.is_present("quick"))
+        .dry_run(matches.is_present("dry-run"))
+        .reboot(matches.is_present("reboot"))
+}

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use crate::lang_impl::LangImpl;
+use crate::limit::Limit;
+
+use std::collections::HashMap;
+
+/// The key of the path tag.
+pub const TAG_PATH: &str = "path";
+
+/// A collection of tags associated with a benchmark.
+///
+/// A tag is a key-value pair. It records both arbitrary values set by the user,
+/// and the results of a benchmark.
+pub type TagStore = HashMap<String, String>;
+
+/// A benchmark, which consists of a set of tags, and a list of language
+/// implementations the benchmark will be run on.
+pub struct Benchmark<'a> {
+    tags: TagStore,
+    lang_impl: &'a dyn LangImpl,
+    /// The stack size limit. `None` by default.
+    pub stack_lim: Option<Limit>,
+    /// The heap size limit. `None` by default.
+    pub heap_lim: Option<Limit>,
+}
+
+impl<'a> Benchmark<'a> {
+    /// Create a new benchmark with the specified path.
+    pub fn new(path: &str, lang_impl: &'a dyn LangImpl) -> Benchmark<'a> {
+        let b = Benchmark {
+            tags: Default::default(),
+            lang_impl,
+            stack_lim: None,
+            heap_lim: None,
+        };
+        // The path tag is mandatory (k2 can't run the benchmark without knowing
+        // the path).
+        b.tag("path", path)
+    }
+
+    /// The path of the benchmark.
+    pub fn path(&self) -> &str {
+        self.tags.get(TAG_PATH).expect("Benchmark path not set.")
+    }
+
+    /// Add tag `t` with value `val`.
+    pub fn tag(mut self, t: &str, val: &str) -> Self {
+        self.tags.insert(t.to_string(), val.to_string());
+        self
+    }
+
+    /// Get the value of the tag with key `t`.
+    fn tag_value(&self, t: &str) -> &str {
+        &self
+            .tags
+            .get(t)
+            .expect(&format!("Tag key {} doesn't have an associated value!", t))
+    }
+
+    /// Check if the value of the tag identified by `t` matches `val`.
+    fn matches_tag(&self, t: &str, val: &str) -> bool {
+        // This function could implement a more sophisticated check to decide whether
+        // `val` is a match.
+        self.tag_value(t) == val
+    }
+
+    pub fn stack_lim(mut self, stack_lim: Limit) -> Self {
+        self.stack_lim = Some(stack_lim);
+        self
+    }
+
+    pub fn heap_lim(mut self, heap_lim: Limit) -> Self {
+        self.heap_lim = Some(heap_lim);
+        self
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use std::time::Duration;
+
+/// The configuration that specifies how to run the benchmarks.
+#[derive(Debug)]
+pub(crate) struct Config {
+    /// The path of the result file.
+    pub result_path: String,
+    /// Run the benchmarks in quick mode (for development/testing purposes).
+    pub quick: bool,
+    /// Don't actually run the benchmarks (for development/testing purposes).
+    pub dry_run: bool,
+    /// Automatically reboot between pexecs.
+    pub reboot: bool,
+    /// The list of emails to send notifications/errors to.
+    pub mail_to: Vec<String>,
+    /// The number of in-process iterations.
+    pub in_proc_iters: usize,
+    /// The number of process executions.
+    pub pexecs: usize,
+    /// The amount of time to wait before taking the initial temperature reading.
+    pub temp_read_pause: Duration,
+}
+
+impl Config {
+    pub fn new() -> Config {
+        Config {
+            result_path: "default/path".to_string(),
+            quick: false,
+            dry_run: false,
+            reboot: false,
+            mail_to: Default::default(),
+            in_proc_iters: 40,
+            pexecs: 1,
+            temp_read_pause: Duration::from_secs(60),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+/// An error describing why an experiment failed.
+#[derive(Debug)]
+pub enum K2Error {
+    Unknown,
+}

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use crate::{benchmark::Benchmark, config::Config, error::K2Error, limit::Limit};
+
+use std::time::Duration;
+
+/// The experiment runner.
+pub struct Experiment<'a> {
+    /// The configuration variables.
+    config: Config,
+    /// The benchmarks to run.
+    benchmarks: Vec<&'a Benchmark<'a>>,
+}
+
+impl<'a> Experiment<'a> {
+    // Private: experiments should always be created through the ExperimentBuilder.
+    fn new(config: Config, benchmarks: Vec<&'a Benchmark>) -> Self {
+        Experiment { config, benchmarks }
+    }
+
+    /// Run the experiment. If experiment completes successfully, return a String
+    /// which represents the path of the results file; otherwise, return a `K2Error`.
+    pub fn run(self) -> Result<String, K2Error> {
+        unimplemented!("run");
+    }
+}
+
+/// A builder used to construct an `Experiment`.
+///
+/// This populates a `Config` struct with values, and collects the benchmarks
+/// to run.
+pub struct ExperimentBuilder<'a> {
+    config: Config,
+    benchmarks: Vec<&'a Benchmark<'a>>,
+}
+
+impl<'a> ExperimentBuilder<'a> {
+    pub fn new() -> Self {
+        ExperimentBuilder {
+            config: Config::new(),
+            benchmarks: Default::default(),
+        }
+    }
+
+    pub fn result_path(mut self, result_path: &str) -> Self {
+        self.config.result_path = result_path.to_string();
+        self
+    }
+
+    pub fn quick(mut self, quick: bool) -> Self {
+        self.config.quick = quick;
+        self
+    }
+
+    pub fn dry_run(mut self, dry_run: bool) -> Self {
+        self.config.dry_run = dry_run;
+        self
+    }
+
+    pub fn reboot(mut self, reboot: bool) -> Self {
+        self.config.reboot = reboot;
+        self
+    }
+
+    pub fn mail_to(mut self, mail_to: Vec<String>) -> Self {
+        self.config.mail_to = mail_to;
+        self
+    }
+
+    pub fn in_proc_iters(mut self, in_proc_iters: usize) -> Self {
+        self.config.in_proc_iters = in_proc_iters;
+        self
+    }
+
+    pub fn pexecs(mut self, pexecs: usize) -> Self {
+        self.config.pexecs = pexecs;
+        self
+    }
+
+    pub fn temp_read_pause(mut self, temp_read_pause: Duration) -> Self {
+        self.config.temp_read_pause = temp_read_pause;
+        self
+    }
+
+    /// Add `bench` to the list of benchmarks to run.
+    pub fn benchmark(mut self, bench: &'a Benchmark) -> Self {
+        self.benchmarks.push(bench);
+        self
+    }
+
+    /// Consume the builder and create an `Experiment` with the `config` and
+    /// `benchmarks` recorded.
+    pub fn build(self) -> Experiment<'a> {
+        Experiment::new(self.config, self.benchmarks)
+    }
+}

--- a/src/lang_impl.rs
+++ b/src/lang_impl.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use std::{collections::HashMap, path::PathBuf};
+
+pub trait LangImpl {
+    fn results_key(&self) -> &str;
+    fn invoke(&self);
+}
+
+pub struct GenericScriptingVm {
+    /// The path of the interpreter.
+    interp_path: PathBuf,
+    /// The environment to use when running the VM.
+    env: HashMap<String, String>,
+}
+
+impl GenericScriptingVm {
+    pub fn new(path: &str) -> GenericScriptingVm {
+        GenericScriptingVm {
+            interp_path: PathBuf::from(path),
+            env: Default::default(),
+        }
+    }
+
+    pub fn env(mut self, k: &str, v: &str) -> GenericScriptingVm {
+        self.env.insert(k.to_string(), v.to_string());
+        self
+    }
+}
+
+impl LangImpl for GenericScriptingVm {
+    fn results_key(&self) -> &str {
+        self.interp_path
+            .to_str()
+            .expect("The path should be valid unicode!")
+    }
+
+    fn invoke(&self) {
+        unimplemented!("invoke");
+    }
+}
+
+pub struct GenericNativeCode {
+    /// The environment to use.
+    pub env: HashMap<String, String>,
+}
+
+impl GenericNativeCode {
+    pub fn new() -> GenericNativeCode {
+        GenericNativeCode {
+            env: Default::default(),
+        }
+    }
+
+    pub fn env(mut self, k: &str, v: &str) -> GenericNativeCode {
+        self.env.insert(k.to_string(), v.to_string());
+        self
+    }
+}
+
+impl LangImpl for GenericNativeCode {
+    fn results_key(&self) -> &str {
+        unimplemented!("results_key");
+    }
+
+    fn invoke(&self) {
+        unimplemented!("invoke");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+pub mod benchmark;
+pub mod config;
+pub mod error;
+pub mod experiment;
+pub mod lang_impl;
+pub mod limit;
+pub mod util;

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+#[derive(Debug)]
+pub enum Limit {
+    KiB(f32),
+    MiB(f32),
+    GiB(f32),
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+/// Return the absolute path of `bin_name` by searching ${PATH}.
+pub fn find_executable(bin_name: &str) -> String {
+    which::which(bin_name)
+        .expect(&format!("Could not find {}.", bin_name))
+        .to_str()
+        .expect("Path must be a utf-8 string.")
+        .into()
+}


### PR DESCRIPTION
This is by no means complete, but I thought I'd ask for some comments before I proceed any further.

I added a `main.rs` to demonstrate a typical use of the `k2` library. Note that most of the values passed to the `ExperimentBuilder` are entirely optional. Using `k2` could be as simple as:

```rust
    let exp = ExperimentBuilder::new()
        .add_lang_impl(&[&lang_impl::HotSpot, &lang_impl::CPython])
        .add_benchmark(Benchmark::new(...))
        .build();
    match exp.run() {
        Ok(result) => {
            CsvWriter::write(&Path::new("./result.csv"), &result);
            KrunV1Writer::write(&Path::new("./result.krun"), &result);
        }
        Err(error) => {
            // Report/handle the error.
        }
    }
```

Here is the breakdown of the library:
* `config.rs`: Contains the `Config` structure. Each `Experiment` has a `Config` instance, which indicates how to run the experiment (whether it must run in `quick` mode, whether to reboot between pexecs, etc). The `Config` can either be generated from a `.toml` file (using `Config::from_file(...)`), or it can be manually populated with values. The `parse_args` function from `main.rs` shows one way the `Config` could be created from command-line arguments, although I think most people would find the former option easier (i.e. using `Config::from_file`).
* `error.rs`: Contains the errors that might occur when running an `Experiment`.
* `experiment.rs`: The `ExperimentBuilder` is used to build and configure the `Experiment`.
The `Experiment` is actually the experiment runner. This also contains the `Benchmark` structure, which is supposed to indicate the path of a particular set of benchmarks. I'm not sure which of  `expb.add_benchmark(["/path/to/benchmark", "arg1", ..., "argn"])` and `expb.add_benchmark(Benchmark::new(...))` would be easier to use... Any thoughts on this?
* `lang_impl.rs`: Contains the languages supported by `k2`, and their implementation of the `LangImpl` trait (as discussed, each language must implement `LangImpl`).
* `limit.rs`: A helper `enum` to indicate stack/heap limits. I'm not sure we actually need this.
* `writer.rs`: contains a `*Writer` for every output format supported. The user of the library has to use these helpers to generate the result file(s). Alternatively, these could be used internally by `k2`.

I haven't thought much about the internal format for `k2`, because I wanted to come up with an API first.

I'm sure I got much of this wrong, so I can't wait to hear your thoughts!