### PR TITLE
Implementation sketch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ path = "src/lib.rs"
 [dependencies]
 clap = "2.33.0"
 which = "2.0.1"
+libc = { version = "0.2.62", default-features = false }
+rand = { version = "0.7", features = ["small_rng"]}
+rusqlite = "0.20.0"

--- a/benchmarks/binarytrees/binarytrees.lua
+++ b/benchmarks/binarytrees/binarytrees.lua
@@ -1,0 +1,79 @@
+-- Copyright © 2004-2008 Brent Fulgham, 2005-2019 Isaac Gouy
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice,
+-- this list of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright
+-- notice, this list of conditions and the following disclaimer in the
+-- documentation and/or other materials provided with the distribution.
+--
+-- 3. Neither the name "The Computer Language Benchmarks Game" nor the name
+-- "The Benchmarks Game" nor the name "The Computer Language Shootout
+-- Benchmarks" nor the names of its contributors may be used to endorse or
+-- promote products derived from this software without specific prior written
+-- permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+-- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-- POSSIBILITY OF SUCH DAMAGE.
+--
+-- https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+-- contributed by Mike Pall
+-- *reset*
+
+local function BottomUpTree(depth)
+  if depth > 0 then
+    depth = depth - 1
+    local left, right = BottomUpTree(depth), BottomUpTree(depth)
+    return { left, right }
+  else
+    return { }
+  end
+end
+
+local function ItemCheck(tree)
+  if tree[1] then
+    return 1 + ItemCheck(tree[1]) + ItemCheck(tree[2])
+  else
+    return 1
+  end
+end
+
+local N = tonumber(arg and arg[1]) or 0
+local mindepth = 4
+local maxdepth = mindepth + 2
+if maxdepth < N then maxdepth = N end
+
+do
+  local stretchdepth = maxdepth + 1
+  local stretchtree = BottomUpTree(stretchdepth)
+  io.write(string.format("stretch tree of depth %d\t check: %d\n",
+    stretchdepth, ItemCheck(stretchtree)))
+end
+
+local longlivedtree = BottomUpTree(maxdepth)
+
+for depth=mindepth,maxdepth,2 do
+  local iterations = 2 ^ (maxdepth - depth + mindepth)
+  local check = 0
+  for i=1,iterations do
+    check = check + ItemCheck(BottomUpTree(depth))
+  end
+  io.write(string.format("%d\t trees of depth %d\t check: %d\n",
+    iterations, depth, check))
+end
+
+io.write(string.format("long lived tree of depth %d\t check: %d\n",
+  maxdepth, ItemCheck(longlivedtree)))

--- a/benchmarks/binarytrees/binarytrees.py
+++ b/benchmarks/binarytrees/binarytrees.py
@@ -1,0 +1,108 @@
+# The Computer Language Benchmarks Game
+#
+# Copyright © 2004-2008 Brent Fulgham, 2005-2019 Isaac Gouy
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name "The Computer Language Benchmarks Game" nor the name
+# "The Benchmarks Game" nor the name "The Computer Language Shootout
+# Benchmarks" nor the names of its contributors may be used to endorse or
+# promote products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+#
+# contributed by Antoine Pitrou
+# modified by Dominique Wahli and Daniel Nanz
+# modified by Joerg Baumann
+
+import sys
+import multiprocessing as mp
+
+
+def make_tree(d):
+
+    if d > 0:
+        d -= 1
+        return (make_tree(d), make_tree(d))
+    return (None, None)
+
+
+def check_tree(node):
+
+    (l, r) = node
+    if l is None:
+        return 1
+    else:
+        return 1 + check_tree(l) + check_tree(r)
+
+
+def make_check(itde, make=make_tree, check=check_tree):
+
+    i, d = itde
+    return check(make(d))
+
+
+def get_argchunks(i, d, chunksize=5000):
+
+    assert chunksize % 2 == 0
+    chunk = []
+    for k in range(1, i + 1):
+        chunk.extend([(k, d)])
+        if len(chunk) == chunksize:
+            yield chunk
+            chunk = []
+    if len(chunk) > 0:
+        yield chunk
+
+
+def main(n, min_depth=4):
+
+    max_depth = max(min_depth + 2, n)
+    stretch_depth = max_depth + 1
+    if mp.cpu_count() > 1:
+        pool = mp.Pool()
+        chunkmap = pool.map
+    else:
+        chunkmap = map
+
+    print('stretch tree of depth {0}\t check: {1}'.format(
+          stretch_depth, make_check((0, stretch_depth))))
+
+    long_lived_tree = make_tree(max_depth)
+
+    mmd = max_depth + min_depth
+    for d in range(min_depth, stretch_depth, 2):
+        i = 2 ** (mmd - d)
+        cs = 0
+        for argchunk in get_argchunks(i,d):
+            cs += sum(chunkmap(make_check, argchunk))
+        print('{0}\t trees of depth {1}\t check: {2}'.format(i, d, cs))
+
+    print('long lived tree of depth {0}\t check: {1}'.format(
+          max_depth, check_tree(long_lived_tree)))
+
+
+if __name__ == '__main__':
+    main(int(sys.argv[1]))

--- a/examples/simple_experiment.rs
+++ b/examples/simple_experiment.rs
@@ -26,11 +26,14 @@ fn main() {
     let pypy = GenericScriptingVm::new(&pypy_bin);
     let luajit = GenericScriptingVm::new(&luajit_bin);
     let cpython_bench = Benchmark::new("./benchmarks/binarytrees/binarytrees.py", &cpython)
-        .tag("benchmark_name", "binarytrees");
+        .tag("benchmark_name", "binarytrees")
+        .arg("10".into());
     let pypy_bench = Benchmark::new("./benchmarks/binarytrees/binarytrees.py", &pypy)
-        .tag("benchmark_name", "binarytrees");
+        .tag("benchmark_name", "binarytrees")
+        .arg("10".into());
     let lua_bench = Benchmark::new("./benchmarks/binarytrees/binarytrees.lua", &luajit)
         .tag("benchmark_name", "binarytrees")
+        .arg("12".into())
         .stack_lim(Limit::KiB(8.192))
         .heap_lim(Limit::GiB(2.097152));
     let exp = expb
@@ -38,12 +41,11 @@ fn main() {
         .benchmark(&pypy_bench)
         .benchmark(&lua_bench)
         .build();
-    // `run` outputs the result in the k2 internal format.
     let _ = exp.run().expect("Failed to run the experiment");
 }
 
 fn setup<'a>() -> ExperimentBuilder<'a> {
-    let expb = parse_args(ExperimentBuilder::new());
+    let expb = parse_args(ExperimentBuilder::new("simple_experiment"));
     // These could've been command-line arguments too.
     expb.pexecs(2).in_proc_iters(40)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,13 +8,13 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 /// The configuration that specifies how to run the benchmarks.
 #[derive(Debug)]
 pub(crate) struct Config {
-    /// The path of the result file.
-    pub result_path: String,
+    /// The path of the directory where to store the results and the manifest.
+    pub results_dir: PathBuf,
     /// Run the benchmarks in quick mode (for development/testing purposes).
     pub quick: bool,
     /// Don't actually run the benchmarks (for development/testing purposes).
@@ -32,9 +32,9 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    pub fn new() -> Config {
+    pub fn new(results_dir: PathBuf) -> Config {
         Config {
-            result_path: "default/path".to_string(),
+            results_dir,
             quick: false,
             dry_run: false,
             reboot: false,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use crate::{
+    benchmark::Benchmark,
+    config::Config,
+    manifest::{Job, JobStatus},
+};
+
+use rusqlite::{self, params, Connection};
+
+use std::path::{Path, PathBuf};
+
+/// A wrapper around the database connection.
+pub(crate) struct K2Store {
+    connection: Option<Connection>,
+    db_path: PathBuf,
+}
+
+impl<'a> K2Store {
+    /// The k2 database file.
+    pub const K2_DB: &'static str = "k2.db";
+
+    pub fn new<P: AsRef<Path>>(k2_dir: P) -> K2Store {
+        // The database connection is not created until it's actually needed.
+        K2Store {
+            connection: None,
+            db_path: k2_dir.as_ref().join(Self::K2_DB),
+        }
+    }
+
+    /// Open a new connection to the SQLite database, and return a reference to it.
+    fn connection(&mut self) -> &Connection {
+        let db_path = &self.db_path;
+        self.connection.get_or_insert_with(|| {
+            Connection::open(db_path).expect("Failed to connect to the k2 database")
+        })
+    }
+
+    /// Create the `job` table.
+    ///
+    /// The table created by this function records the status and key of each job.
+    pub fn create_job_table(&mut self, config: &Config, benchmarks: &[&'_ Benchmark]) {
+        let connection = self.connection();
+        connection
+            .execute("CREATE TABLE job(
+                        job_id INTEGER PRIMARY KEY,
+                        key TEXT NOT NULL,
+                        status INTEGER NOT NULL);", rusqlite::NO_PARAMS)
+            .expect("Failed to create the job table");
+        let mut stmt = connection
+            .prepare("INSERT INTO job VALUES ($1, $2, $3)")
+            .expect("Failed to prepare query.");
+        let mut id = 0;
+        for _ in 0..config.pexecs {
+            for bench in benchmarks {
+                let job = Job::new(id, &bench);
+                id += 1;
+                stmt
+                    .execute(params![job.id as i64, job.key, job.status as i64])
+                    .expect("Failed to populate the job table");
+            }
+        }
+    }
+
+    /// Set the status of the job with identifier `id` to `status`.
+    pub fn update_status(&mut self, id: usize, status: JobStatus) {
+        let connection = self.connection();
+        let mut stmt = connection
+            .prepare("UPDATE job SET status = $1 WHERE job_id = $2;")
+            .expect("Failed to prepare query.");
+        stmt
+            .execute(params![status as i64, id as i64])
+            .expect("Failed to create the job table");
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,4 +12,6 @@
 #[derive(Debug)]
 pub enum K2Error {
     Unknown,
+    ExecutionFailed,
+    RerunError,
 }

--- a/src/experiment.rs
+++ b/src/experiment.rs
@@ -8,9 +8,20 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-use crate::{benchmark::Benchmark, config::Config, error::K2Error, limit::Limit};
+use crate::{
+    benchmark::Benchmark,
+    config::Config,
+    db::K2Store,
+    error::K2Error,
+    manifest::{JobStatus, ManifestManager},
+    util,
+};
 
-use std::time::Duration;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 /// The experiment runner.
 pub struct Experiment<'a> {
@@ -18,18 +29,70 @@ pub struct Experiment<'a> {
     config: Config,
     /// The benchmarks to run.
     benchmarks: Vec<&'a Benchmark<'a>>,
+    /// An interface to the manifest used to schedule benchmark execution.
+    manifest: ManifestManager,
+    /// Whether is is the first run of the experiment.
+    first_run: bool,
+    /// An interface to the underlying database.
+    store: K2Store,
 }
 
 impl<'a> Experiment<'a> {
     // Private: experiments should always be created through the ExperimentBuilder.
     fn new(config: Config, benchmarks: Vec<&'a Benchmark>) -> Self {
-        Experiment { config, benchmarks }
+        let first_run = if Path::new(&config.results_dir).exists() {
+            false
+        } else {
+            // Create a directory to store the results and the manifest.
+            fs::create_dir(&config.results_dir).expect("Failed to create results dir");
+            true
+        };
+        let manifest = ManifestManager::new(&config, &benchmarks);
+        let store = K2Store::new(&config.results_dir);
+        Experiment {
+            config,
+            benchmarks,
+            manifest,
+            first_run,
+            store,
+        }
     }
 
     /// Run the experiment. If experiment completes successfully, return a String
     /// which represents the path of the results file; otherwise, return a `K2Error`.
-    pub fn run(self) -> Result<String, K2Error> {
-        unimplemented!("run");
+    pub fn run(mut self) -> Result<PathBuf, K2Error> {
+        // Run the next outstanding benchmark.
+        if let Some(job) = self.manifest.next_job() {
+            // `job` is the index of the next job to run. Each benchmark is run
+            // `config.pexecs` times, so we use modular arithmetic to work out the
+            // index of the next benchmark to run.
+            let bench = &self.benchmarks[job % self.benchmarks.len()];
+            let result = bench.run(&self.config);
+            let status = match result {
+                Ok(_) => JobStatus::Done,
+                Err(K2Error::RerunError) => JobStatus::Outstanding,
+                Err(_) => JobStatus::Error,
+            };
+            // If we've just run the first job, create all the necessary tables.
+            if self.first_run {
+                // Create a table to store the status of each job.
+                self.store.create_job_table(&self.config, &self.benchmarks);
+                // FIXME: create a table for the measurements too.
+            }
+            // Update the status of the job we've just run.
+            self.manifest.update_status(status);
+            // Increment `num_reboots`, since we are about to reboot before running
+            // the next job.
+            self.manifest.update_num_reboots();
+            // FIXME: Record the measurements for this benchmark.
+            // Persist all the changes.
+            self.manifest.sync(&mut self.store);
+            // Reboot before running the next job.
+            Err(util::reboot(self.config.reboot))
+        } else {
+            // There are no more benchmarks to run: return the path.
+            Ok(self.config.results_dir.join(K2Store::K2_DB))
+        }
     }
 }
 
@@ -43,15 +106,18 @@ pub struct ExperimentBuilder<'a> {
 }
 
 impl<'a> ExperimentBuilder<'a> {
-    pub fn new() -> Self {
+    /// Set up a new experiment builder.
+    ///
+    /// The experiment results and manifest are stored in `results_dir`.
+    pub fn new<P: AsRef<Path>>(results_dir: P) -> Self {
         ExperimentBuilder {
-            config: Config::new(),
+            config: Config::new(results_dir.as_ref().into()),
             benchmarks: Default::default(),
         }
     }
 
-    pub fn result_path(mut self, result_path: &str) -> Self {
-        self.config.result_path = result_path.to_string();
+    pub fn results_dir<P: AsRef<Path>>(mut self, results_dir: P) -> Self {
+        self.config.results_dir = results_dir.as_ref().to_path_buf();
         self
     }
 

--- a/src/lang_impl.rs
+++ b/src/lang_impl.rs
@@ -8,11 +8,14 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
-use std::{collections::HashMap, path::PathBuf};
+use crate::benchmark::Benchmark;
+
+use std::{collections::HashMap, path::PathBuf, process::Command};
 
 pub trait LangImpl {
     fn results_key(&self) -> &str;
-    fn invoke(&self);
+    /// Run the language implementation on the specified benchmark.
+    fn invoke(&self, benchmark: &Benchmark);
 }
 
 pub struct GenericScriptingVm {
@@ -43,8 +46,13 @@ impl LangImpl for GenericScriptingVm {
             .expect("The path should be valid unicode!")
     }
 
-    fn invoke(&self) {
-        unimplemented!("invoke");
+    fn invoke(&self, benchmark: &Benchmark) {
+        let _ = Command::new(&self.interp_path)
+            .arg(benchmark.path())
+            .args(benchmark.args())
+            .envs(&self.env)
+            .output()
+            .expect("failed to execute process");
     }
 }
 
@@ -71,7 +79,7 @@ impl LangImpl for GenericNativeCode {
         unimplemented!("results_key");
     }
 
-    fn invoke(&self) {
+    fn invoke(&self, _benchmark: &Benchmark) {
         unimplemented!("invoke");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@
 
 pub mod benchmark;
 pub mod config;
+pub mod db;
 pub mod error;
 pub mod experiment;
 pub mod lang_impl;
 pub mod limit;
+pub mod manifest;
 pub mod util;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,279 @@
+// Copyright (c) 2019 Gabriela Alexandra Moldovan
+// Copyright (c) 2019 King's College London.
+// Created by the Software Development Team https://soft-dev.org
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0>, or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, or the UPL-1.0 license <http://opensource.org/licenses/UPL>
+// at your option. This file may not be copied, modified, or distributed except according to those
+// terms.
+
+use crate::{benchmark::Benchmark, config::Config, db::K2Store, util::num_digits};
+
+use rand::{self, seq::SliceRandom};
+
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{BufRead, BufReader, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum JobStatus {
+    Outstanding,
+    Done,
+    Error,
+}
+
+#[derive(Debug)]
+pub(crate) struct Job {
+    /// The unique identifier of the job. This is used as a primary key for the `job`
+    /// table.
+    pub id: usize,
+    /// A string that identifies the benchmark/language implementation associated
+    /// with this job.
+    pub key: String,
+    /// The status of this job.
+    pub status: JobStatus,
+}
+
+impl Job {
+    pub fn new(id: usize, bench: &Benchmark) -> Job {
+        Job {
+            id,
+            key: bench.results_key(),
+            status: JobStatus::Outstanding,
+        }
+    }
+}
+
+/// The `num_reboots` field of the manifest header.
+const NUM_REBOOTS: &str = "num_reboots";
+/// The `num_reboots` field has a fixed width of 8 bytes.
+const NUM_REBOOTS_BYTES: usize = 8;
+/// The `next_idx` field of the manifest header.
+const NEXT_IDX: &str = "next_idx";
+/// The `next_idx` field has a fixed width of 4 bytes.
+const NEXT_IDX_BYTES: usize = 4;
+/// The `ordering` field of the manifest header.
+const ORDERING: &str = "ordering";
+
+/// The type of an offset in the manifest header file.
+type Offset = u64;
+
+/// Format `value` as a string of `width` bytes, padding with zeroes if necessary.
+///
+/// # Panics
+///
+/// Panics if the string representation of `value` exceeds `width` bytes.
+fn format_int_field(value: usize, width: usize) -> String {
+    let bytes = num_digits(value);
+    assert!(bytes <= width, "{} <= {} is false", bytes, width);
+    let padding = width - bytes;
+    format!("{}{}", "0".repeat(padding as usize), value)
+}
+
+#[derive(Debug)]
+struct ManifestHeader {
+    /// The path of the header.
+    hdr_path: PathBuf,
+    /// The value of the `num_reboots` field.
+    num_reboots: usize,
+    /// The offset of the `num_reboots` field.
+    num_reboots_offset: Offset,
+    /// The value of the `next_idx` field.
+    next_idx: usize,
+    /// The offset of the `next_idx` field.
+    next_idx_offset: Offset,
+    /// The value of the `ordering` field. This field indicates the order in which
+    /// to run the jobs.
+    ordering: Vec<usize>,
+}
+
+impl ManifestHeader {
+    /// The name of the manifest header file.
+    const MANIFEST_HDR: &'static str = "manifest.k2";
+
+    pub fn new<P: AsRef<Path>>(results_dir: P, num_jobs: usize) -> ManifestHeader {
+        let hdr_path = results_dir.as_ref().join(Self::MANIFEST_HDR);
+        if !Path::new(&hdr_path).exists() {
+            // Create a blank manifest header file. The `ordering` field contains a
+            // permutation of the numbers from 0 to `num_jobs` (the jobs are run in
+            // random order).
+            ManifestHeader {
+                hdr_path: hdr_path.clone(),
+                num_reboots: 0,
+                num_reboots_offset: 0,
+                next_idx: 0,
+                next_idx_offset: 0,
+                ordering: ManifestHeader::random_ordering(num_jobs),
+            }
+            .write();
+        }
+        // Parse the file to work out the actual field offsets.
+        ManifestHeader::parse(&hdr_path)
+    }
+
+    fn parse<P: AsRef<Path>>(path: P) -> ManifestHeader {
+        // The fields of the manifest header.
+        let mut num_reboots: Option<(usize, Offset)> = None;
+        let mut next_idx: Option<(usize, Offset)> = None;
+        let mut ordering: Option<Vec<usize>> = None;
+        let file = File::open(&path).expect("Failed to read manifest header");
+        // The offset of the current line.
+        let mut offset = 0;
+        for line in BufReader::new(file).lines() {
+            let line = line.expect("Failed to read line");
+            // Each line is a key-value pair.
+            let mut pair = line.split('=');
+            let key = pair.next().expect("No key specified");
+            let value = pair.next().expect("No value specified");
+            assert!(pair.next().is_none(), "Broken line: {}", line);
+            match key {
+                ORDERING => {
+                    let value = value
+                        .split(',')
+                        .map(|x| x.parse::<usize>().unwrap())
+                        .collect();
+                    ordering = Some(value)
+                }
+                key => {
+                    // Get the actual width of this field.
+                    let val_bytes = value.len();
+                    let value = value
+                        .to_string()
+                        .parse::<usize>()
+                        .unwrap_or_else(|_| panic!("{} must be a usize", key));
+                    // The offset of this field. Add 1 to skip over the '='.
+                    let val_offset = (offset + key.len() + 1) as Offset;
+                    // Get the expected width of this field.
+                    let width = match key {
+                        NUM_REBOOTS => {
+                            num_reboots = Some((value, val_offset));
+                            NUM_REBOOTS_BYTES
+                        }
+                        NEXT_IDX => {
+                            next_idx = Some((value, val_offset));
+                            NEXT_IDX_BYTES
+                        }
+                        &_ => panic!("Unexpected key {}", key),
+                    };
+                    // Make sure the `num_reboots` and `next_idx` fields have the
+                    // expected width.
+                    assert!(val_bytes == width);
+                }
+            }
+            // Add 1 to the offset of the current line to account for newline character.
+            offset += line.len() + 1;
+        }
+        let (num_reboots, num_reboots_offset) = num_reboots
+            .unwrap_or_else(|| panic!("{} key not set", NUM_REBOOTS));
+        let (next_idx, next_idx_offset) = next_idx
+            .unwrap_or_else(|| panic!("{} key not set", NEXT_IDX));
+        ManifestHeader {
+            hdr_path: PathBuf::from(path.as_ref()),
+            num_reboots,
+            num_reboots_offset,
+            next_idx,
+            next_idx_offset,
+            ordering: ordering.expect("ordering key not set"),
+        }
+    }
+
+    /// Create the manifest header file.
+    fn write(&self) {
+        let num_reboots = format_int_field(self.num_reboots, NUM_REBOOTS_BYTES);
+        let next_idx = format_int_field(self.next_idx, NEXT_IDX_BYTES);
+        if !Path::new(&self.hdr_path).exists() {
+            let manifest_hdr = format!("{}={}\n{}={}\n{}={}",
+                NUM_REBOOTS, num_reboots,
+                NEXT_IDX, next_idx,
+                ORDERING, self.ordering_str());
+            fs::write(&self.hdr_path, manifest_hdr).expect("Failed to write the manifest header");
+        }
+    }
+
+    fn ordering_str(&self) -> String {
+        let ordering: Vec<String> = self.ordering.iter().map(|x| x.to_string()).collect();
+        ordering.join(",")
+    }
+
+    /// Update the `num_reboots` and `next_idx` fields.
+    fn sync(&self) {
+        let num_reboots = format_int_field(self.num_reboots, NUM_REBOOTS_BYTES);
+        let next_idx = format_int_field(self.next_idx, NEXT_IDX_BYTES);
+        match OpenOptions::new().write(true).open(&self.hdr_path) {
+            Ok(mut f) => {
+                f.seek(SeekFrom::Start(self.num_reboots_offset)).unwrap();
+                f.write(num_reboots.as_bytes()).unwrap();
+                f.seek(SeekFrom::Start(self.next_idx_offset)).unwrap();
+                f.write(next_idx.as_bytes()).unwrap();
+            }
+            Err(err) => panic!("Failed to open manifest header: {}", err),
+        }
+    }
+
+    /// Generate a random permutation for the job ordering.
+    fn random_ordering(num_jobs: usize) -> Vec<usize> {
+        let mut ordering: Vec<usize> = (0..num_jobs).collect();
+        ordering.shuffle(&mut rand::thread_rng());
+        ordering
+    }
+}
+
+pub(crate) struct ManifestManager {
+    /// The manifest header.
+    manifest_hdr: ManifestHeader,
+    /// The status of the current job.
+    cur_status: JobStatus,
+}
+
+impl ManifestManager {
+    pub fn new(config: &Config, benchmarks: &[&'_ Benchmark]) -> ManifestManager {
+        let num_jobs = config.pexecs * benchmarks.len();
+        let manifest_hdr = ManifestHeader::new(&config.results_dir, num_jobs);
+        ManifestManager {
+            manifest_hdr,
+            cur_status: JobStatus::Outstanding,
+        }
+    }
+
+    /// Returns the index of the next job to run, or `None` if there are no more
+    /// outstanding jobs.
+    pub fn next_job(&self) -> Option<usize> {
+        if self.manifest_hdr.next_idx < self.manifest_hdr.ordering.len() {
+            Some(self.manifest_hdr.ordering[self.manifest_hdr.next_idx])
+        } else {
+            None
+        }
+    }
+
+    /// Updates the status of the current job to `status`.
+    pub fn update_status(&mut self, status: JobStatus) {
+        self.cur_status = status;
+        match status {
+            JobStatus::Done | JobStatus::Error => {
+                self.manifest_hdr.next_idx += 1;
+                let bytes = num_digits(self.manifest_hdr.next_idx);
+                assert!(bytes <= NEXT_IDX_BYTES, "{} <= {} is false", bytes, NEXT_IDX_BYTES);
+            }
+            _ => {}
+        }
+    }
+
+    /// Increments the number of reboots.
+    pub fn update_num_reboots(&mut self) {
+        let bytes = num_digits(self.manifest_hdr.num_reboots);
+        assert!(bytes <= NUM_REBOOTS_BYTES, "{} <= {} is false", bytes, NUM_REBOOTS_BYTES);
+        self.manifest_hdr.num_reboots += 1;
+    }
+
+    /// Writes the manifest header and the status of the current job.
+    pub fn sync(&self, store: &mut K2Store) {
+        self.manifest_hdr.sync();
+        store.update_status(
+            self.manifest_hdr.ordering[self.manifest_hdr.next_idx - 1],
+            self.cur_status,
+        );
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,11 +8,43 @@
 // at your option. This file may not be copied, modified, or distributed except according to those
 // terms.
 
+use crate::error::K2Error;
+
+use libc::c_char;
+use std::{ffi, ptr};
+
 /// Return the absolute path of `bin_name` by searching ${PATH}.
 pub fn find_executable(bin_name: &str) -> String {
     which::which(bin_name)
-        .expect(&format!("Could not find {}.", bin_name))
+        .unwrap_or_else(|_| panic!("Could not find {}.", bin_name))
         .to_str()
         .expect("Path must be a utf-8 string.")
         .into()
+}
+
+/// Reboot, if `hardware_reboot` is `true`. Otherwise, replace the current process
+/// with a fresh copy of itself.
+pub fn reboot(hardware_reboot: bool) -> K2Error {
+    if hardware_reboot {
+        unimplemented!("reboot")
+    } else {
+        let args = std::env::args();
+        let mut cstrs = Vec::with_capacity(args.len());
+        for arg in args {
+            cstrs.push(ffi::CString::new(arg).unwrap());
+        }
+        let mut argv: Vec<*const c_char> = cstrs.iter().map(|arg| arg.as_ptr()).collect();
+        argv.push(ptr::null());
+        unsafe { libc::execv(argv[0], argv.as_ptr()) };
+        K2Error::Unknown
+    }
+}
+
+/// Return the number of digits in `value`.
+pub fn num_digits(value: usize) -> usize {
+    if value == 0 {
+        1
+    } else {
+        (value as f64).log10().floor() as usize + 1
+    }
 }


### PR DESCRIPTION
This PR contains the first draft of the implementation:
* e2d203e `Config` (the configuration struct used to configure experiments) now also contains `results_dir` (the path of the directory where `k2` stores all the files it creates).
* c579fc1 adds the manifest manager. I know `krun` has its own manifest format, but I wasn't sure we wanted this for `k2` as well. The `k2` manifest is a json file with all the information needed  to resume execution after rebooting (it's still missing a couple of values we will need, like the starting temperatures). For example, the manifest might look like this:
```
{
    "num_reboots": 6,
    "num_mails_sent": 0,
    "curr_job_idx": 4,
    "jobs": [
        {
            "key": "/usr/bin/python:./benchmarks/binarytrees/binarytrees.py",
            "bench_idx": 0,
            "status": "Done"
        },
        { ... },
        ...
    ]
}
```

[I don't think we actually need the `key` field, since I'm using `bench_idx` as an identifier for benchmarks]

Let me know if you think another format would work better.

* d6d2416 contains the code that actually runs the benchmarks. The experiment runner runs the next outstanding benchmark, and [retrieves its tags](https://github.com/softdevteam/k2/blob/d6d24167bff4656d87652014b01fee6f0c86534d/src/experiment.rs#L60). The tags are supposed to contain all the values measured/recorded, but I haven't implemented that yet, so the 'measurements' are discarded (they'll eventually be stored in an SQLite database). After each benchmark run, the manifest is updated and [explictly written to disk](https://github.com/softdevteam/k2/blob/d6d24167bff4656d87652014b01fee6f0c86534d/src/experiment.rs#L72-L75).
* cd9cffb adds a `reboot` function. If `hardware_reboots` is `false`, this function simulates a reboot (like `krun`) by replacing the process image with a fresh version of itself. `reboot` is unimplemented for the `hardware_reboots == true`case .

* 357e84b adds the `binarytrees` benchmark used in `example/simple_example.rs`
